### PR TITLE
Fix example for the last task of homework 9 - 1-2 group

### DIFF
--- a/lab1-2/homework-9/README.md
+++ b/lab1-2/homework-9/README.md
@@ -68,7 +68,7 @@ dictionary "The quick brown fox jumps over the lazy dog" -> [("the", 2), ("quick
 **Сигнатура:**
 
 ```haskell
-tdidf :: String -> String -> [String] -> Float
+tfidf :: String -> String -> [String] -> Float
 ```
 
 **Примери:**


### PR DESCRIPTION
Трябва да е 'This' вместо 'the', защото по-надолу в примера е написано, че 'the' се среща в два от документите. 
